### PR TITLE
fix: translate "server" to french in title page

### DIFF
--- a/views/fr/servers/index.html
+++ b/views/fr/servers/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>Suivix - Sélection d'un server</title>
+    <title>Suivix - Sélection d'un serveur</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description"


### PR DESCRIPTION
I just retranslated the word in french, it must have been a mistake.